### PR TITLE
Fix day after tomorrow at end of the year

### DIFF
--- a/main.js
+++ b/main.js
@@ -91,7 +91,7 @@ class Feiertage extends utils.Adapter {
         let datommoEaster = easter;
         let datommoAdvent4 = advent4;
         if (datommo > 365 + isLeap) {
-            datommo = 1;
+            datommo = 2;
         }
         if (datommo < todayIs) {
             datommoYear++;


### PR DESCRIPTION
On December 31, the day after tomorrow must be January 2.