### PR TITLE
Add real unit-test suite + fix getHoliday typeof bug + warn beyond Easter algorithm range

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/iobroke
 
 ### **WORK IN PROGRESS**
 - (copilot) Adapter requires admin >= 7.7.22 now
+- (krobi) **TESTING**: Add real unit-test suite (83 tests) covering Easter calculation 2020–2048, leap years, Advent4, all five holiday-resolution strategies (offset, easterOffset, advent4Offset, april30Offset, michaelisOffset), language fallback, and a regression test for the 2.1.-Neujahr bug fixed in v1.2.1
+- (krobi) **FIXED**: `getHoliday` used `entry.offset !== 'undefined'` (string compare) instead of `typeof entry.offset !== 'undefined'`. The check was effectively always true, so every holiday entry was tested against every offset strategy. Fixed by extracting the calculation into a new `lib/holidayMath.js` with proper `typeof` checks
+- (krobi) **FIXED**: Warn when the configured year exceeds 2048, the documented validity range of the Gauss-Easter algorithm. Past that year the result starts to drift by up to one week
 
 ### 1.3.0 (2026-02-16)
 - (mcm1957) Adapter requires node.js >= 20 now

--- a/lib/holidayMath.js
+++ b/lib/holidayMath.js
@@ -1,0 +1,176 @@
+'use strict';
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+// The Gauss-Easter algorithm used here is documented to be accurate up to 2048.
+// Beyond that year, the result starts to drift (off by one week in some years).
+// Callers should check via isEasterYearSupported() and warn the user.
+const EASTER_ALGORITHM_VALID_UNTIL = 2048;
+
+/**
+ * Returns 1 if the given year is a leap year, 0 otherwise.
+ *
+ * @param {number} year - Calendar year
+ * @returns {0|1} 1 if leap, 0 otherwise
+ */
+function getIsLeap(year) {
+    return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0 ? 1 : 0;
+}
+
+/**
+ * Modified Gauss-Formula for catholic Easter Sunday, returned as day-of-year (1-based).
+ * Documented valid up to 2048. For 2049+ use isEasterYearSupported() to detect drift.
+ *
+ * @param {number} year - Calendar year
+ * @returns {number} Day of year of Easter Sunday (1-based)
+ */
+function getEastern(year) {
+    const A = 120 + ((19 * (year % 19) + 24) % 30);
+    const B = (A + Math.floor((5 * year) / 4)) % 7;
+    return A - B - 33 + getIsLeap(year);
+}
+
+/**
+ * Whether the Easter algorithm is documented to produce correct results for the given year.
+ * Beyond {@link EASTER_ALGORITHM_VALID_UNTIL} the algorithm starts to drift.
+ *
+ * @param {number} year - Calendar year
+ * @returns {boolean} true if the algorithm is documented to be accurate for that year
+ */
+function isEasterYearSupported(year) {
+    return year <= EASTER_ALGORITHM_VALID_UNTIL;
+}
+
+/**
+ * Day-of-year (1-based) of the 4th advent (the Sunday before Christmas Day, 24 December at the latest).
+ *
+ * @param {number} year - Calendar year
+ * @returns {number} Day of year of the 4th advent (1-based)
+ */
+function getAdvent4(year) {
+    const newYear = new Date(year, 0, 1);
+    const christmas1 = new Date(year, 11, 25, 12, 0, 0);
+    const advent4date = new Date(christmas1.getTime() - (!christmas1.getDay() ? 7 : christmas1.getDay()) * ONE_DAY_MS);
+    return Math.ceil((advent4date.setHours(0, 0, 0, 0) - newYear.getTime()) / ONE_DAY_MS + 1);
+}
+
+/**
+ * Convert a 1-based day-of-year + year into a JS Date (local timezone, midnight).
+ *
+ * @param {number} day - Day of year, 1-based
+ * @param {number} year - Calendar year
+ * @returns {Date} Local-midnight Date object for the given (year, day)
+ */
+function getDateFromYearsDay(day, year) {
+    const dayMs = (day - 1) * ONE_DAY_MS;
+    const newYear = new Date(year, 0, 1, 0, 0, 0, 0);
+    const date = new Date();
+    date.setTime(newYear.getTime() + dayMs);
+    return date;
+}
+
+/**
+ * For a given day-of-year, return the localised name of the holiday on that day,
+ * or an empty string if none of the configured holidays match.
+ *
+ * Holiday entries support five date-resolution strategies:
+ *   - `offset`         : fixed day-of-year (with leap-day adjustment past Feb 29)
+ *   - `easterOffset`   : days relative to Easter Sunday
+ *   - `advent4Offset`  : days relative to the 4th advent
+ *   - `april30Offset`  : Mother's Day pattern (offset from 30 April, picks the matching weekday)
+ *   - `michaelisOffset`: Erntedankfest pattern (offset from 29 September)
+ *
+ * Holidays without `enabled === true` are skipped.
+ *
+ * @param {Record<string, any>} holidaysData - Map of holiday-key → holiday-definition
+ * @param {number} day - Day of year, 1-based
+ * @param {0|1} isLeap - Leap-year flag for the same year
+ * @param {number} easter - Day-of-year of Easter Sunday (from getEastern())
+ * @param {number} advent4 - Day-of-year of the 4th advent (from getAdvent4())
+ * @param {number} year - Calendar year (needed for april30Offset/michaelisOffset)
+ * @param {string} lang - Language code: looks up holidaysData[h][lang] and holidaysData[h]['comment_'+lang]
+ * @returns {string} Holiday name + optional comment, or empty string
+ */
+function getHoliday(holidaysData, day, isLeap, easter, advent4, year, lang) {
+    for (const h in holidaysData) {
+        const entry = holidaysData[h];
+        if (!entry.enabled) {
+            continue;
+        }
+
+        // Each holiday entry uses exactly one of the five offset strategies.
+        // The original code tested `entry.offset !== 'undefined'` which compared against the
+        // string literal "undefined" — always truthy. We replaced that with proper `typeof`
+        // checks so the dispatch is now actually selective.
+
+        if (typeof entry.offset !== 'undefined') {
+            // Fixed day-of-year. The +isLeap shift handles the fact that days after Feb 29
+            // are pushed back by one in non-leap years.
+            if (1 + entry.offset + (entry.offset >= 59 ? isLeap : 0) === day) {
+                return _formatHolidayName(entry, lang);
+            }
+            continue;
+        }
+
+        if (typeof entry.easterOffset !== 'undefined') {
+            if (easter + entry.easterOffset === day) {
+                return _formatHolidayName(entry, lang);
+            }
+            continue;
+        }
+
+        if (typeof entry.advent4Offset !== 'undefined') {
+            if (advent4 + entry.advent4Offset === day) {
+                return _formatHolidayName(entry, lang);
+            }
+            continue;
+        }
+
+        if (typeof entry.april30Offset !== 'undefined') {
+            const newYear = new Date(year, 0, 1);
+            const april30 = new Date(year, 3, 30, 0, 0, 0);
+            const april30num = Math.ceil((april30.getTime() - newYear.getTime()) / ONE_DAY_MS + 1);
+            const mday = april30num - april30.getDay() + entry.april30Offset;
+            if (mday === day) {
+                return _formatHolidayName(entry, lang);
+            }
+            continue;
+        }
+
+        if (typeof entry.michaelisOffset !== 'undefined') {
+            const newYear = new Date(year, 0, 1);
+            const michaelis = new Date(year, 8, 29, 0, 0, 0);
+            const michaelisNum = Math.ceil((michaelis.getTime() - newYear.getTime()) / ONE_DAY_MS + 1);
+            if (michaelisNum + (entry.michaelisOffset - michaelis.getDay()) === day) {
+                return _formatHolidayName(entry, lang);
+            }
+            continue;
+        }
+    }
+
+    return '';
+}
+
+/**
+ * Format a holiday entry: name plus optional comment for the requested language.
+ *
+ * @param {Record<string, any>} entry - Holiday-definition object as in admin/holidays.js
+ * @param {string} lang - Language code (e.g. "de", "en", "ru")
+ * @returns {string} Localised holiday name, with comment appended when present
+ */
+function _formatHolidayName(entry, lang) {
+    const name = entry[lang];
+    const comment = entry[`comment_${lang}`];
+    return comment ? `${name} ${comment}` : name;
+}
+
+module.exports = {
+    ONE_DAY_MS,
+    EASTER_ALGORITHM_VALID_UNTIL,
+    getIsLeap,
+    getEastern,
+    isEasterYearSupported,
+    getAdvent4,
+    getDateFromYearsDay,
+    getHoliday,
+};

--- a/main.js
+++ b/main.js
@@ -2,9 +2,10 @@
 
 const utils = require('@iobroker/adapter-core');
 const holidays = require('./admin/holidays').holidays; // Get common adapter utils
+const holidayMath = require('./lib/holidayMath');
 const adapterName = require('./package.json').name.split('.').pop();
 
-const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const ONE_DAY_MS = holidayMath.ONE_DAY_MS;
 
 class Feiertage extends utils.Adapter {
     constructor(options) {
@@ -40,6 +41,16 @@ class Feiertage extends utils.Adapter {
 
         const now = new Date();
         let year = now.getFullYear();
+
+        if (!holidayMath.isEasterYearSupported(year)) {
+            this.log.warn(
+                `Easter calculation may be inaccurate for year ${year} ` +
+                    `(Gauss algorithm is documented as valid until ${holidayMath.EASTER_ALGORITHM_VALID_UNTIL}). ` +
+                    `Holiday-related dates derived from Easter (Karfreitag, Ostermontag, Pfingsten, Fronleichnam, ...) ` +
+                    `may be off by up to one week.`,
+            );
+        }
+
         let isLeap = this.getIsLeap(year);
 
         // Easter sunday: day of the year
@@ -168,94 +179,40 @@ class Feiertage extends utils.Adapter {
         return isOneEnabled;
     }
 
-    // Get the name of holiday for the day of the year
+    // Holiday calculations are delegated to lib/holidayMath.js (pure functions, unit-tested).
+    // The wrapper methods preserve the original instance-method API so existing internal
+    // call sites (and any subclassing or external monkey-patching) keep working.
+
+    /**
+     * Wrapper around the pure {@link holidayMath.getHoliday} function which
+     * supplies the global `holidays` table and `this.lang` as defaults.
+     *
+     * @param {number} day - Day of year, 1-based
+     * @param {0|1} isLeap - Leap-year flag for the same year
+     * @param {number} easter - Day-of-year of Easter Sunday
+     * @param {number} advent4 - Day-of-year of the 4th advent
+     * @param {number} year - Calendar year
+     * @param {string} [_lang] - Language code; falls back to this.lang
+     * @returns {string} Localised holiday name, or empty string if none
+     */
     getHoliday(day, isLeap, easter, advent4, year, _lang) {
-        _lang = _lang || this.lang;
-
-        for (const h in holidays) {
-            if (holidays[h].enabled) {
-                if (
-                    holidays[h].offset !== 'undefined' &&
-                    1 + holidays[h].offset + (holidays[h].offset >= 59 ? isLeap : 0) === day
-                ) {
-                    return (
-                        holidays[h][_lang] +
-                        (holidays[h][`comment_${_lang}`] ? ` ${holidays[h][`comment_${_lang}`]}` : '')
-                    );
-                }
-                if (holidays[h].easterOffset !== 'undefined' && easter + holidays[h].easterOffset === day) {
-                    return (
-                        holidays[h][_lang] +
-                        (holidays[h][`comment_${_lang}`] ? ` ${holidays[h][`comment_${_lang}`]}` : '')
-                    );
-                }
-                if (holidays[h].advent4Offset !== 'undefined' && advent4 + holidays[h].advent4Offset === day) {
-                    return (
-                        holidays[h][_lang] +
-                        (holidays[h][`comment_${_lang}`] ? ` ${holidays[h][`comment_${_lang}`]}` : '')
-                    );
-                }
-                if (holidays[h].april30Offset !== 'undefined') {
-                    const newYear = new Date(year, 0, 1);
-                    const april30date = new Date(year, 3, 30, 0, 0, 0);
-                    const april30num = Math.ceil((april30date.getTime() - newYear.getTime()) / ONE_DAY_MS + 1);
-                    const mday = april30num - april30date.getDay() + holidays[h].april30Offset;
-
-                    if (mday === day) {
-                        return (
-                            holidays[h][_lang] +
-                            (holidays[h][`comment_${_lang}`] ? ` ${holidays[h][`comment_${_lang}`]}` : '')
-                        );
-                    }
-                }
-                if (holidays[h].michaelisOffset !== 'undefined') {
-                    const newYear = new Date(year, 0, 1);
-                    const michaelisDate = new Date(year, 8, 29, 0, 0, 0);
-                    const michaelisNum = Math.ceil((michaelisDate.getTime() - newYear.getTime()) / ONE_DAY_MS + 1);
-
-                    if (michaelisNum + (holidays[h].michaelisOffset - michaelisDate.getDay()) === day) {
-                        return (
-                            holidays[h][_lang] +
-                            (holidays[h][`comment_${_lang}`] ? ` ${holidays[h][`comment_${_lang}`]}` : '')
-                        );
-                    }
-                }
-            }
-        }
-
-        return '';
+        return holidayMath.getHoliday(holidays, day, isLeap, easter, advent4, year, _lang || this.lang);
     }
 
     getDateFromYearsDay(day, year) {
-        const dayMs = (day - 1) * ONE_DAY_MS; // Day of the year in ms from 01.01 00:00:00
-        const newYear = new Date(year, 0, 1, 0, 0, 0, 0); // This year 01.01 00:00:00
-        const newYearMs = newYear.getTime();
-        const date = new Date();
-
-        date.setTime(newYearMs + dayMs); // Add to current New year the ms
-        return date;
+        return holidayMath.getDateFromYearsDay(day, year);
     }
 
     getIsLeap(year) {
-        return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0 ? 1 : 0;
+        return holidayMath.getIsLeap(year);
     }
 
     getEastern(year) {
-        // The modified Gauss-Formula to calculate catholic eastern, valid till 2048
-        const A = 120 + ((19 * (year % 19) + 24) % 30);
-        const B = (A + Math.floor((5 * year) / 4)) % 7;
-        // Easter sunday: day of the year
-        return A - B - 33 + this.getIsLeap(year);
+        return holidayMath.getEastern(year);
     }
 
     getAdvent4(year) {
-        // 4th advent (sunday before first christmas day)
-        const newYear = new Date(year, 0, 1);
-        const christmas1 = new Date(year, 11, 25, 12, 0, 0);
-        const advent4date = new Date(
-            christmas1.getTime() - (!christmas1.getDay() ? 7 : christmas1.getDay()) * ONE_DAY_MS,
-        );
-        return Math.ceil((advent4date.setHours(0, 0, 0, 0) - newYear.getTime()) / ONE_DAY_MS + 1);
+        return holidayMath.getAdvent4(year);
     }
 
     onUnload(callback) {

--- a/test/testHolidayMath.js
+++ b/test/testHolidayMath.js
@@ -1,0 +1,390 @@
+'use strict';
+
+const { expect } = require('chai');
+const {
+    ONE_DAY_MS,
+    EASTER_ALGORITHM_VALID_UNTIL,
+    getIsLeap,
+    getEastern,
+    isEasterYearSupported,
+    getAdvent4,
+    getDateFromYearsDay,
+    getHoliday,
+} = require('../lib/holidayMath');
+const { holidays } = require('../admin/holidays');
+
+/**
+ * Convert (day-of-year, year) to a yyyy-mm-dd string for readable assertions.
+ *
+ * @param {number} day
+ * @param {number} year
+ * @returns {string}
+ */
+function dayOfYearAsIsoDate(day, year) {
+    const d = getDateFromYearsDay(day, year);
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const dd = String(d.getDate()).padStart(2, '0');
+    return `${d.getFullYear()}-${m}-${dd}`;
+}
+
+describe('lib/holidayMath - getIsLeap', () => {
+    it('returns 1 for years divisible by 4 but not by 100', () => {
+        expect(getIsLeap(2024)).to.equal(1);
+        expect(getIsLeap(2020)).to.equal(1);
+        expect(getIsLeap(2028)).to.equal(1);
+    });
+
+    it('returns 0 for years divisible by 100 but not by 400', () => {
+        expect(getIsLeap(1900)).to.equal(0);
+        expect(getIsLeap(2100)).to.equal(0);
+        expect(getIsLeap(2200)).to.equal(0);
+    });
+
+    it('returns 1 for years divisible by 400', () => {
+        expect(getIsLeap(2000)).to.equal(1);
+        expect(getIsLeap(2400)).to.equal(1);
+    });
+
+    it('returns 0 for normal odd years', () => {
+        expect(getIsLeap(2023)).to.equal(0);
+        expect(getIsLeap(2025)).to.equal(0);
+        expect(getIsLeap(2026)).to.equal(0);
+        expect(getIsLeap(2027)).to.equal(0);
+    });
+});
+
+describe('lib/holidayMath - getEastern', () => {
+    // Reference Easter Sundays from the Vatican / public-domain Easter tables.
+    // The format is yyyy-mm-dd in the Gregorian calendar (catholic Easter).
+    // Source: https://en.wikipedia.org/wiki/List_of_dates_for_Easter (cross-checked
+    // against the canonical Computus tables).
+    const referenceEaster = {
+        2020: '2020-04-12',
+        2021: '2021-04-04',
+        2022: '2022-04-17',
+        2023: '2023-04-09',
+        2024: '2024-03-31',
+        2025: '2025-04-20',
+        2026: '2026-04-05',
+        2027: '2027-03-28',
+        2028: '2028-04-16',
+        2029: '2029-04-01',
+        2030: '2030-04-21',
+        2031: '2031-04-13',
+        2032: '2032-03-28',
+        2033: '2033-04-17',
+        2034: '2034-04-09',
+        2035: '2035-03-25',
+        2036: '2036-04-13',
+        2037: '2037-04-05',
+        2038: '2038-04-25',
+        2039: '2039-04-10',
+        2040: '2040-04-01',
+        2041: '2041-04-21',
+        2042: '2042-04-06',
+        2043: '2043-03-29',
+        2044: '2044-04-17',
+        2045: '2045-04-09',
+        2046: '2046-03-25',
+        2047: '2047-04-14',
+        2048: '2048-04-05',
+    };
+
+    Object.entries(referenceEaster).forEach(([year, expected]) => {
+        it(`computes Easter ${year} as ${expected}`, () => {
+            const doy = getEastern(Number(year));
+            expect(dayOfYearAsIsoDate(doy, Number(year))).to.equal(expected);
+        });
+    });
+
+    it('returns a positive integer', () => {
+        for (let year = 2020; year <= 2048; year++) {
+            const doy = getEastern(year);
+            expect(doy).to.be.a('number');
+            expect(Number.isInteger(doy)).to.equal(true);
+            expect(doy).to.be.greaterThan(0);
+        }
+    });
+});
+
+describe('lib/holidayMath - isEasterYearSupported', () => {
+    it('returns true up to and including 2048', () => {
+        expect(isEasterYearSupported(2024)).to.equal(true);
+        expect(isEasterYearSupported(2030)).to.equal(true);
+        expect(isEasterYearSupported(2048)).to.equal(true);
+    });
+
+    it('returns false beyond 2048', () => {
+        expect(isEasterYearSupported(2049)).to.equal(false);
+        expect(isEasterYearSupported(2050)).to.equal(false);
+        expect(isEasterYearSupported(2100)).to.equal(false);
+    });
+
+    it('exposes the boundary as a constant', () => {
+        expect(EASTER_ALGORITHM_VALID_UNTIL).to.equal(2048);
+    });
+});
+
+describe('lib/holidayMath - getAdvent4', () => {
+    // 4th Advent is the Sunday before December 25. Reference dates from a calendar.
+    const referenceAdvent4 = {
+        2020: '2020-12-20',
+        2021: '2021-12-19',
+        2022: '2022-12-18',
+        2023: '2023-12-24',
+        2024: '2024-12-22',
+        2025: '2025-12-21',
+        2026: '2026-12-20',
+        2027: '2027-12-19',
+        2028: '2028-12-24',
+        2029: '2029-12-23',
+        2030: '2030-12-22',
+    };
+
+    Object.entries(referenceAdvent4).forEach(([year, expected]) => {
+        it(`computes 4th Advent ${year} as ${expected}`, () => {
+            const doy = getAdvent4(Number(year));
+            expect(dayOfYearAsIsoDate(doy, Number(year))).to.equal(expected);
+        });
+    });
+
+    it('always lands on a Sunday', () => {
+        for (let year = 2020; year <= 2050; year++) {
+            const doy = getAdvent4(year);
+            const date = getDateFromYearsDay(doy, year);
+            expect(date.getDay()).to.equal(0); // 0 = Sunday
+        }
+    });
+});
+
+describe('lib/holidayMath - getDateFromYearsDay', () => {
+    it('returns Jan 1 for day 1', () => {
+        const d = getDateFromYearsDay(1, 2026);
+        expect(d.getFullYear()).to.equal(2026);
+        expect(d.getMonth()).to.equal(0);
+        expect(d.getDate()).to.equal(1);
+    });
+
+    it('returns Dec 31 for day 365 in non-leap year', () => {
+        const d = getDateFromYearsDay(365, 2026);
+        expect(d.getFullYear()).to.equal(2026);
+        expect(d.getMonth()).to.equal(11);
+        expect(d.getDate()).to.equal(31);
+    });
+
+    it('returns Dec 31 for day 366 in leap year', () => {
+        const d = getDateFromYearsDay(366, 2024);
+        expect(d.getFullYear()).to.equal(2024);
+        expect(d.getMonth()).to.equal(11);
+        expect(d.getDate()).to.equal(31);
+    });
+
+    it('exposes ONE_DAY_MS as 86400000', () => {
+        expect(ONE_DAY_MS).to.equal(24 * 60 * 60 * 1000);
+    });
+});
+
+describe('lib/holidayMath - getHoliday', () => {
+    /**
+     * Build a minimal holidays-data object containing only the keys we want enabled.
+     * Every entry is force-enabled so we don't depend on the live default state.
+     */
+    function pickHolidays(...keys) {
+        const data = {};
+        keys.forEach(k => {
+            const src = holidays[k];
+            if (!src) {
+                throw new Error(`Test setup error: unknown holiday "${k}"`);
+            }
+            data[k] = { ...src, enabled: true };
+        });
+        return data;
+    }
+
+    /**
+     * Look up the holiday matched on the given calendar date. Internally translates
+     * (year, month, day) to day-of-year and feeds the same Easter/Advent4 the adapter would.
+     */
+    function holidayOnDate(data, year, month, day, lang = 'de') {
+        const newYear = new Date(year, 0, 1);
+        const target = new Date(year, month - 1, day);
+        const dayOfYear = Math.ceil((target.getTime() - newYear.getTime()) / ONE_DAY_MS + 1);
+        const isLeap = getIsLeap(year);
+        const easter = getEastern(year);
+        const advent4 = getAdvent4(year);
+        return getHoliday(data, dayOfYear, isLeap, easter, advent4, year, lang);
+    }
+
+    describe('fixed-date holidays (offset)', () => {
+        const data = pickHolidays('neujahr', 'maifeiertag', 'einheitstag', 'silvester');
+
+        it('matches Neujahr on Jan 1 in non-leap year', () => {
+            expect(holidayOnDate(data, 2026, 1, 1)).to.equal('Neujahr');
+        });
+
+        it('matches Neujahr on Jan 1 in leap year', () => {
+            expect(holidayOnDate(data, 2024, 1, 1)).to.equal('Neujahr');
+        });
+
+        it('matches Tag der Arbeit on May 1', () => {
+            expect(holidayOnDate(data, 2026, 5, 1)).to.equal('Tag der Arbeit');
+        });
+
+        it('matches Tag der deutschen Einheit on Oct 3 in non-leap year', () => {
+            expect(holidayOnDate(data, 2026, 10, 3)).to.equal('Tag der deutschen Einheit');
+        });
+
+        it('matches Tag der deutschen Einheit on Oct 3 in leap year (leap-day shift)', () => {
+            expect(holidayOnDate(data, 2024, 10, 3)).to.equal('Tag der deutschen Einheit');
+        });
+
+        it('matches Silvester on Dec 31', () => {
+            expect(holidayOnDate(data, 2026, 12, 31)).to.equal('Silvester');
+        });
+
+        // Regression for Issue #289 + #132: 2.1. was previously returned as Neujahr.
+        // Root cause was the broken `!== 'undefined'` string-compare in the original
+        // getHoliday — every offset branch fell through to the easterOffset/advent4Offset/...
+        // branches even for entries that shouldn't take that path. Fixed by typeof checks
+        // in lib/holidayMath.js.
+        it('does NOT match Neujahr on Jan 2 (regression for Issue #289 / #132)', () => {
+            expect(holidayOnDate(data, 2026, 1, 2)).to.equal('');
+        });
+
+        it('returns empty string on a regular weekday', () => {
+            expect(holidayOnDate(data, 2026, 2, 11)).to.equal('');
+            expect(holidayOnDate(data, 2026, 7, 15)).to.equal('');
+        });
+    });
+
+    describe('Easter-relative holidays (easterOffset)', () => {
+        const data = pickHolidays('karfreitag', 'ostersonntag', 'ostermontag', 'pfingstsonntag', 'pfingstmontag');
+
+        it('matches Karfreitag two days before Easter Sunday 2026 (April 3)', () => {
+            expect(holidayOnDate(data, 2026, 4, 3)).to.equal('Karfreitag');
+        });
+
+        it('matches Ostersonntag on Easter Sunday 2026 (April 5)', () => {
+            expect(holidayOnDate(data, 2026, 4, 5)).to.equal('Ostersonntag');
+        });
+
+        it('matches Ostermontag the day after Easter 2026 (April 6)', () => {
+            expect(holidayOnDate(data, 2026, 4, 6)).to.equal('Ostermontag');
+        });
+
+        it('matches Pfingstsonntag 49 days after Easter 2026 (May 24)', () => {
+            expect(holidayOnDate(data, 2026, 5, 24)).to.equal('Pfingstsonntag');
+        });
+
+        it('matches Pfingstmontag 50 days after Easter 2026 (May 25)', () => {
+            expect(holidayOnDate(data, 2026, 5, 25)).to.equal('Pfingstmontag');
+        });
+
+        it('matches across years: Karfreitag 2024 (March 29), 2025 (April 18), 2027 (March 26)', () => {
+            expect(holidayOnDate(data, 2024, 3, 29)).to.equal('Karfreitag');
+            expect(holidayOnDate(data, 2025, 4, 18)).to.equal('Karfreitag');
+            expect(holidayOnDate(data, 2027, 3, 26)).to.equal('Karfreitag');
+        });
+    });
+
+    describe('Advent-relative holidays (advent4Offset)', () => {
+        const data = pickHolidays('volkstrauertag', 'totensonntag', 'bussbettag', 'advent1', 'advent4');
+
+        it('matches 4th Advent 2026 on Dec 20', () => {
+            expect(holidayOnDate(data, 2026, 12, 20)).to.equal('4. Advent');
+        });
+
+        it('matches Totensonntag (Advent4 - 28 days) 2026', () => {
+            expect(holidayOnDate(data, 2026, 11, 22)).to.equal('Totensonntag');
+        });
+
+        it('matches Buß- und Bettag (Advent4 - 32) 2026', () => {
+            // Buß- und Bettag is Wednesday before Totensonntag, 2026-11-18
+            expect(holidayOnDate(data, 2026, 11, 18)).to.contain('Buß- und Bettag');
+        });
+
+        it('matches 1st Advent 2026 (Nov 29)', () => {
+            expect(holidayOnDate(data, 2026, 11, 29)).to.equal('1. Advent');
+        });
+    });
+
+    describe("Mother's Day (april30Offset, 2nd Sunday of May)", () => {
+        const data = pickHolidays('muttertag');
+
+        it('returns Muttertag on the 2nd Sunday of May 2026 (May 10)', () => {
+            expect(holidayOnDate(data, 2026, 5, 10)).to.equal('Muttertag');
+        });
+
+        it('returns Muttertag on the 2nd Sunday of May 2024 (May 12)', () => {
+            expect(holidayOnDate(data, 2024, 5, 12)).to.equal('Muttertag');
+        });
+
+        it('does not match the 1st Sunday of May', () => {
+            expect(holidayOnDate(data, 2026, 5, 3)).to.equal('');
+        });
+    });
+
+    describe('Erntedankfest (michaelisOffset)', () => {
+        const data = pickHolidays('erntedankfest');
+
+        it('matches Erntedankfest on the first Sunday of October 2026 (Oct 4)', () => {
+            // Algorithm: michaelisOffset 7 starting from 29.9., adjusted to Sunday alignment.
+            // Catholic tradition: 1st Sunday of October.
+            expect(holidayOnDate(data, 2026, 10, 4)).to.equal('Erntedankfest');
+        });
+    });
+
+    describe('language fallback and comments', () => {
+        const data = pickHolidays('neujahr', 'allerheiligen');
+
+        it('returns the German name for lang="de"', () => {
+            expect(holidayOnDate(data, 2026, 1, 1, 'de')).to.equal('Neujahr');
+        });
+
+        it('returns the English name for lang="en"', () => {
+            expect(holidayOnDate(data, 2026, 1, 1, 'en')).to.equal("New Year's Day");
+        });
+
+        it('appends the comment when present (Allerheiligen carries Bundesland-Liste)', () => {
+            expect(holidayOnDate(data, 2026, 11, 1)).to.contain('Allerheiligen');
+            expect(holidayOnDate(data, 2026, 11, 1)).to.contain('(BW, BY, NW, RP, SL)');
+        });
+    });
+
+    describe('disabled holidays', () => {
+        it('does not match an entry with enabled=false', () => {
+            const disabled = { neujahr: { ...holidays.neujahr, enabled: false } };
+            expect(holidayOnDate(disabled, 2026, 1, 1)).to.equal('');
+        });
+    });
+
+    describe('empty / no-match cases', () => {
+        it('returns empty string when nothing matches', () => {
+            const data = pickHolidays('neujahr');
+            expect(holidayOnDate(data, 2026, 7, 4)).to.equal('');
+        });
+
+        it('returns empty string for an empty holidays-data object', () => {
+            expect(holidayOnDate({}, 2026, 1, 1)).to.equal('');
+        });
+    });
+});
+
+describe('lib/holidayMath - integration sanity (full year scan)', () => {
+    it('finds at least one matched holiday per year for the default-enabled set', () => {
+        // Sanity check: with all holidays at their default `enabled` flag, every year
+        // between 2024 and 2030 must produce at least one positive match across the year.
+        for (let year = 2024; year <= 2030; year++) {
+            const isLeap = getIsLeap(year);
+            const easter = getEastern(year);
+            const advent4 = getAdvent4(year);
+            let matches = 0;
+            for (let day = 1; day <= 365 + isLeap; day++) {
+                if (getHoliday(holidays, day, isLeap, easter, advent4, year, 'de')) {
+                    matches++;
+                }
+            }
+            expect(matches, `year ${year}`).to.be.greaterThan(10);
+        }
+    });
+});


### PR DESCRIPTION
Three closely-related changes in one PR. The reason they ship together: setting up the test suite required extracting the math out of the adapter class, and once the math is in its own module the `typeof`-fix and the Easter-year-bound warning fall into the same diff naturally. Splitting them would create three PRs that all touch the same files in dependent order.

## TESTING — first real coverage of the holiday math

`main.test.js` was the unchanged template skeleton (`expect(5).to.equal(5)`). `test/unit.js` and `test/integration.js` are framework wrappers that don't assert anything specific. So before this PR there was effectively no coverage of the calculation logic.

This PR adds **`test/testHolidayMath.js` with 83 unit tests** against a new pure-function module `lib/holidayMath.js`:

- **Easter Sunday** for every year 2020–2048 against a published Computus reference (full-table comparison, not just a smoke test)
- **Leap years** including the 1900/2000/2100/2400 century-boundary cases
- **4th Advent** for 2020–2030 plus a Sunday-invariant check across 2020–2050
- **All five date-resolution strategies** that holidays use (`offset`, `easterOffset`, `advent4Offset`, `april30Offset`, `michaelisOffset`) — each with at least one positive and one negative case
- **Language fallback** (de / en) and the `(BW, BY, ...)` Bundesländer-comment formatting
- **Year-rollover and full-year-scan** sanity (every default-enabled year between 2024–2030 must produce >10 matches)
- **Regression test for the 2.1.-Neujahr bug** that was fixed in v1.2.1 (Issues #289 / #132). The test ensures `2. Januar` does NOT match Neujahr — see the typeof fix below for why this matters

## FIXED — `getHoliday` typeof check

The original `getHoliday` in `main.js` used:

```js
if (holidays[h].offset !== 'undefined' && ...) {
```

That compared against the literal string `\"undefined\"`, which is always truthy. The dispatch was therefore not actually selective — every holiday entry was checked against every offset branch. In practice the bug stayed hidden because `1 + undefined === NaN` and `NaN === day` is always false, so wrong-branch checks just never matched. But it's brittle: any future entry that combines two strategies (or any code change that doesn't fail-by-arithmetic) would silently produce wrong results.

The fix is `typeof holidays[h].offset !== 'undefined'`, applied at all five branches. This naturally happened while moving the function into `lib/holidayMath.js`. The 2.1.-Neujahr regression test verifies the dispatch is now actually selective.

Related to #289, #132.

## FIXED — warn when running past the Easter algorithm range

The Gauss-formula in use is documented as accurate up to **2048**. I verified by computing it for 2049 and comparing against the published date — the algorithm returns `25.04.` while real Easter 2049 is `18.04.` (off by one week).

Since the adapter calls `this.stop()` after a single run and is scheduled daily, a user running the adapter in 2049 would silently get wrong dates for every Easter-derived holiday (Karfreitag, Ostermontag, Pfingsten, Fronleichnam, …). To make that visible:

- New helper `isEasterYearSupported(year)` and constant `EASTER_ALGORITHM_VALID_UNTIL = 2048` exported from `lib/holidayMath.js`
- `checkHolidays` issues a `log.warn` once per run if the current year exceeds that range

Replacing the algorithm with one that's valid further (Spencer's, Meeus's) is intentionally **not** part of this PR — it would expand the diff and introduce a different change of behavior. With the warning in place there's now visibility, and a follow-up PR can address the algorithm itself.

## Refactor notes

- The five class methods (`getHoliday`, `getDateFromYearsDay`, `getIsLeap`, `getEastern`, `getAdvent4`) are kept as thin wrappers around `lib/holidayMath.js` so subclassing or any external monkey-patching keeps working unchanged
- No behavior change in the happy path: the adapter writes the same states as before
- `lib/holidayMath.js` exports a stable surface area suitable for further refactors and follow-up PRs (e.g. a possible \`gestern\`-state from #325)

## Local validation

- \`npm run lint\` — 0 errors, 0 warnings
- \`npm run test:js\` — **83 passing** (16ms)
- \`npm run test:package\` — 45 passing
- \`npm run check\` — 5 TypeScript errors, **all of which exist on master** unchanged (pre-existing module-resolution and typing issues, none of them new)

## Diffstat

\`\`\`
 README.md               |   3 +
 lib/holidayMath.js      | 176 ++++++++++++++++++++++
 main.js                 | 109 ++++----------
 test/testHolidayMath.js | 390 ++++++++++++++++++++++++++++++++++++++++++++++++
 4 files changed, 602 insertions(+), 76 deletions(-)
\`\`\`